### PR TITLE
Disable menu by default

### DIFF
--- a/header.php
+++ b/header.php
@@ -38,6 +38,7 @@
 							'container'      => 'nav',
 							'theme_location' => 'primary',
 							'container_class'     => 'links',
+                            'fallback_cb' => false
 						);
 						wp_nav_menu( $menu_array );
 						?>


### PR DESCRIPTION
To keep a clean demo, it is better to not show the menu items at all, unless the
user setup through “Customize” in order to display the right format.
